### PR TITLE
Example of Passing Arguments via `privatelyAssemble`

### DIFF
--- a/GrassChoppers/Features/Home/HomeRouter.swift
+++ b/GrassChoppers/Features/Home/HomeRouter.swift
@@ -12,7 +12,7 @@ class HomeFeatureRouter: HomeRouting {
     }
     
     func routeToNextScreen() {
-        let listViewController = resolver.resolve(ServiceHistoryFeature.self)!.createEntryViewController()
+        let listViewController = resolver.resolve(ServiceHistoryFeature.self)!.createEntryViewController(somethingFromHome: "some data from home")
         viewController?.present(listViewController, animated: true, completion: nil)
     }
 }

--- a/GrassChoppers/Features/ServiceHistory/ServiceHistoryDataManager.swift
+++ b/GrassChoppers/Features/ServiceHistory/ServiceHistoryDataManager.swift
@@ -12,11 +12,17 @@ protocol ServiceHistoryDataManagingDelegate {
 class ServiceHistoryDataManager: ServiceHistoryDataManaging {
     var delegate: ServiceHistoryDataManagingDelegate?
     
+    private let somethingFromHome: String
+    
+    init(somethingFromHome: String) {
+        self.somethingFromHome = somethingFromHome
+    }
+    
     func requestInitialState() {
         deliverHistory()
     }
     
     private func deliverHistory() {
-        delegate?.didFetchHistory(services: ["Jonah", "Travis", "Witcig"])
+        delegate?.didFetchHistory(services: ["Jonah", "Travis", "Witcig", somethingFromHome])
     }
 }

--- a/GrassChoppers/Features/ServiceHistory/ServiceHistoryFeature.swift
+++ b/GrassChoppers/Features/ServiceHistory/ServiceHistoryFeature.swift
@@ -8,11 +8,9 @@ class ServiceHistoryFeature: Assembly {
         parentContainer: Container
     ) {
         self.container = Container(parent: parentContainer)
-        
-        privatelyAssemble()
     }
     
-    func privatelyAssemble() {
+    func privatelyAssemble(somethingFromHome: String) {
         
         ListAssembly(
             parentContainer: container,
@@ -25,7 +23,7 @@ class ServiceHistoryFeature: Assembly {
                     adapter: adapter
                 )
             },
-            dataFactory: { _ in ServiceHistoryDataManager() },
+            dataFactory: { _ in ServiceHistoryDataManager(somethingFromHome: somethingFromHome) },
             routerFactory: ServiceHistoryFeatureRouter.init
         ).assemble(container: container)
         
@@ -37,7 +35,8 @@ class ServiceHistoryFeature: Assembly {
         }
     }
     
-    func createEntryViewController() -> UIViewController {
+    func createEntryViewController(somethingFromHome: String) -> UIViewController {
+        privatelyAssemble(somethingFromHome: somethingFromHome)
         return container.resolve(ListModuleType.self)!.createViewController()
     }
 }


### PR DESCRIPTION
You can use privatelyAssemble in a feature/module’s Assembly as an opportunity to take arguments that one of the components needs (components are VC, LC, DM, etc). If privatelyAssemble is used in the Assembly’s init, you dont yet have the args available (init is run when the enclosing feature is assembled, probably compile time). If you move privatelyAssemble to execute right before the resolving of the entry view controller in createEntryViewController (or createViewController if implementing in a module), the arguments can come from the createEntryViewController/createViewController function, which will be called from a router.